### PR TITLE
updated gemfile to fix ruby racer compile error in 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'http://rubygems.org'
 #gem 'rails', '3.0.9'
 gem 'rails', '3.1.0'
 
-gem 'therubyracer'
+gem 'therubyracer', '>= 0.10.1'
 
 # Asset template engines
 gem 'sass-rails', "~> 3.1.0.rc"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,7 @@ GEM
       railties (~> 3.0)
       thor (~> 0.14)
     json (1.6.1)
-    libv8 (3.3.10.2)
+    libv8 (3.3.10.4)
     mail (2.3.0)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -124,7 +124,7 @@ GEM
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
     temple (0.3.4)
-    therubyracer (0.9.8)
+    therubyracer (0.10.1)
       libv8 (~> 3.3.10)
     thor (0.14.6)
     tilt (1.3.3)
@@ -150,5 +150,5 @@ DEPENDENCIES
   slim
   slim-rails
   sqlite3-ruby
-  therubyracer
+  therubyracer (>= 0.10.1)
   uglifier


### PR DESCRIPTION
Here's the error I was getting, works fine now:

```
Installing therubyracer (0.9.8) with native extensions 
Gem::Installer::ExtensionBuildError: ERROR: Failed to build gem native extension.

        /Users/yuletide/.rvm/rubies/ruby-1.9.3-p125/bin/ruby extconf.rb 
checking for main() in -lobjc... yes
creating Makefile

make
compiling rr.cpp
clang: warning: argument unused during compilation: '-rdynamic'
rr.cpp:48:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
rr.cpp:151:44: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
    return String::New(RSTRING_PTR(value), RSTRING_LEN(value));
                                           ^~~~~~~~~~~~~~~~~~
/Users/yuletide/.rvm/rubies/ruby-1.9.3-p125/include/ruby-1.9.1/ruby/ruby.h:674:6: note: expanded from macro 'RSTRING_LEN'
     RSTRING_EMBED_LEN(str) : \
     ^
/Users/yuletide/.rvm/rubies/ruby-1.9.3-p125/include/ruby-1.9.1/ruby/ruby.h:670:6: note: expanded from macro 'RSTRING_EMBED_LEN'
     (long)((RBASIC(str)->flags >> RSTRING_EMBED_LEN_SHIFT) & \
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rr.cpp:151:44: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
    return String::New(RSTRING_PTR(value), RSTRING_LEN(value));
                                           ^~~~~~~~~~~~~~~~~~
/Users/yuletide/.rvm/rubies/ruby-1.9.3-p125/include/ruby-1.9.1/ruby/ruby.h:675:28: note: expanded from macro 'RSTRING_LEN'
     RSTRING(str)->as.heap.len)
                           ^
3 warnings generated.
compiling v8.cpp
clang: warning: argument unused during compilation: '-rdynamic'
compiling v8_array.cpp
clang: warning: argument unused during compilation: '-rdynamic'
compiling v8_callbacks.cpp
clang: warning: argument unused during compilation: '-rdynamic'
compiling v8_context.cpp
clang: warning: argument unused during compilation: '-rdynamic'
compiling v8_date.cpp
clang: warning: argument unused during compilation: '-rdynamic'
compiling v8_debug.cpp
clang: warning: argument unused during compilation: '-rdynamic'
compiling v8_exception.cpp
clang: warning: argument unused during compilation: '-rdynamic'
v8_exception.cpp:10:16: warning: unused variable 'stack' [-Wunused-variable]
  static void* stack[20];
               ^
1 warning generated.
compiling v8_external.cpp
clang: warning: argument unused during compilation: '-rdynamic'
v8_external.cpp:10:9: warning: unused variable 'references' [-Wunused-variable]
  VALUE references;
        ^
1 warning generated.
compiling v8_function.cpp
clang: warning: argument unused during compilation: '-rdynamic'
v8_function.cpp:24:23: error: variable length array of non-POD element type 'Handle<v8::Value>'
    Handle<Value> argv[argc];
                      ^
v8_function.cpp:36:23: error: variable length array of non-POD element type 'Handle<v8::Value>'
    Handle<Value> argv[argc];
                      ^
2 errors generated.
make: *** [v8_function.o] Error 1


Gem files will remain installed in /Users/yuletide/.rvm/gems/ruby-1.9.3-p125/gems/therubyracer-0.9.8 for inspection.
Results logged to /Users/yuletide/.rvm/gems/ruby-1.9.3-p125/gems/therubyracer-0.9.8/ext/v8/gem_make.out
An error occured while installing therubyracer (0.9.8), and Bundler cannot continue.
Make sure that `gem install therubyracer -v '0.9.8'` succeeds before bundling.
```
