### PR TITLE
Fix for yosemite bundle issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GEM
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.2)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.11)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -76,7 +76,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.1)
-    ref (1.0.5)
+    ref (2.0.0)
     rspec-core (2.14.8)
     rspec-expectations (2.14.5)
       diff-lcs (>= 1.1.3, < 2.0)
@@ -119,7 +119,7 @@ GEM
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
     temple (0.6.7)
-    therubyracer (0.12.1)
+    therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
     thor (0.19.1)
@@ -151,3 +151,6 @@ DEPENDENCIES
   sqlite3-ruby
   therubyracer
   uglifier
+
+BUNDLED WITH
+   1.10.5


### PR DESCRIPTION
Without this update:
Installing libv8 3.16.14.3 with native extensions

Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

./siteconf20150806-97204-1paxmy2.rb extconf.rb
creating Makefile
Compiling v8 for x64
Using python 2.7.9
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr
--with-gxx-include-dir=/usr/include/c++/4.2.1
Using compiler: /usr/bin/g++
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr
--with-gxx-include-dir=/usr/include/c++/4.2.1
../src/cached-powers.cc:136:18: error: unused variable
'kCachedPowersLength' [-Werror,-Wunused-const-variable]
static const int kCachedPowersLength = ARRAY_SIZE(kCachedPowers);
                 ^
1 error generated.
extconf failed, exit code 1

An error occurred while installing libv8 (3.16.14.3), and Bundler cannot
continue.
Make sure that `gem install libv8 -v '3.16.14.3'` succeeds before
bundling.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/nathanvda/cocoon_simple_form_demo/10)

<!-- Reviewable:end -->
