### PR TITLE
get rid of ActiveRecord::Migration error - Directly inheriting from A…

### DIFF
--- a/db/migrate/20110209224148_create_projects.rb
+++ b/db/migrate/20110209224148_create_projects.rb
@@ -1,4 +1,4 @@
-class CreateProjects < ActiveRecord::Migration
+class CreateProjects < ActiveRecord::Migration[5.2]
   def self.up
     create_table :projects do |t|
       t.string :name

--- a/db/migrate/20110209224224_create_tasks.rb
+++ b/db/migrate/20110209224224_create_tasks.rb
@@ -1,4 +1,4 @@
-class CreateTasks < ActiveRecord::Migration
+class CreateTasks < ActiveRecord::Migration[5.2]
   def self.up
     create_table :tasks do |t|
       t.string :name

--- a/db/migrate/20110209224916_add_missing_fields.rb
+++ b/db/migrate/20110209224916_add_missing_fields.rb
@@ -1,4 +1,4 @@
-class AddMissingFields < ActiveRecord::Migration
+class AddMissingFields < ActiveRecord::Migration[5.2]
   def self.up
     add_column :projects, :description, :string
     add_column :tasks,    :done,        :boolean

--- a/db/migrate/20110424123905_create_people.rb
+++ b/db/migrate/20110424123905_create_people.rb
@@ -1,4 +1,4 @@
-class CreatePeople < ActiveRecord::Migration
+class CreatePeople < ActiveRecord::Migration[5.2]
   def self.up
     create_table :people do |t|
       t.string :name

--- a/db/migrate/20110821153931_create_sub_tasks.rb
+++ b/db/migrate/20110821153931_create_sub_tasks.rb
@@ -1,4 +1,4 @@
-class CreateSubTasks < ActiveRecord::Migration
+class CreateSubTasks < ActiveRecord::Migration[5.2]
   def change
     create_table :sub_tasks do |t|
       t.string :name

--- a/db/migrate/20111009154958_add_owner_to_project.rb
+++ b/db/migrate/20111009154958_add_owner_to_project.rb
@@ -1,4 +1,4 @@
-class AddOwnerToProject < ActiveRecord::Migration
+class AddOwnerToProject < ActiveRecord::Migration[5.2]
   def up
     add_column :projects, :owner_id, :integer
   end

--- a/db/migrate/20111014204238_create_tags.rb
+++ b/db/migrate/20111014204238_create_tags.rb
@@ -1,4 +1,4 @@
-class CreateTags < ActiveRecord::Migration
+class CreateTags < ActiveRecord::Migration[5.2]
   def change
     create_table :tags do |t|
       t.string :name

--- a/db/migrate/20111014204318_create_project_tags.rb
+++ b/db/migrate/20111014204318_create_project_tags.rb
@@ -1,4 +1,4 @@
-class CreateProjectTags < ActiveRecord::Migration
+class CreateProjectTags < ActiveRecord::Migration[5.2]
   def change
     create_table :project_tags do |t|
       t.integer :project_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -9,56 +8,56 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20111014204318) do
+ActiveRecord::Schema.define(version: 2011_10_14_204318) do
 
-  create_table "people", :force => true do |t|
-    t.string   "name"
-    t.string   "role"
-    t.string   "description"
-    t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "people", force: :cascade do |t|
+    t.string "name"
+    t.string "role"
+    t.string "description"
+    t.integer "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "project_tags", :force => true do |t|
-    t.integer  "project_id"
-    t.integer  "tag_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "project_tags", force: :cascade do |t|
+    t.integer "project_id"
+    t.integer "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "projects", :force => true do |t|
-    t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.string   "description"
-    t.integer  "owner_id"
+  create_table "projects", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "description"
+    t.integer "owner_id"
   end
 
-  create_table "sub_tasks", :force => true do |t|
-    t.string   "name"
-    t.string   "description"
-    t.boolean  "done"
-    t.integer  "task_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "sub_tasks", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.boolean "done"
+    t.integer "task_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "tags", :force => true do |t|
-    t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table "tasks", :force => true do |t|
-    t.string   "name"
-    t.string   "description"
-    t.integer  "project_id"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.boolean  "done"
+  create_table "tasks", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.integer "project_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "done"
   end
 
 end


### PR DESCRIPTION
I tried to run the demo so I can learn how this gem works but I encountered an error when I ran `rails db:migrate`. I'll post the snippet of the error below.
Fixed it and thought it will be nice to contribute the fix back to this repo. Hoping it will save someone else the hassle. 

```
cocoon_simple_form_demo (master) $ rails db:migrate
rails aborted!
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateProjects < ActiveRecord::Migration[4.2]
```